### PR TITLE
[Staging Release - 1.2.1] - Handle orphan consents and consumer-unknown users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consent-manager",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Prometheus-X Consent Manager",
   "main": "dist/src/index.js",
   "scripts": {

--- a/src/controllers/consentsController.ts
+++ b/src/controllers/consentsController.ts
@@ -505,7 +505,31 @@ export const giveConsent = async (
         triggerDataExchange,
       });
 
-      if (emailReattachedResponse.status !== 200) {
+      if (emailReattachedResponse?.case === "no-consumer-identifier") {
+        // Consumer has never registered this user: auto-register them on the
+        // consumer side (consumer DSC -> registrationUri) instead of failing.
+        const registerNewUserToConsumerSideResponse =
+          await registerNewUserToConsumerSide({
+            privacyNotice,
+            req,
+            providerUserIdentifier,
+            dataProvider,
+            dataConsumer,
+            providerUserIdentifierDocument,
+            data,
+            dataProcessingId,
+          });
+
+        if (registerNewUserToConsumerSideResponse.error) {
+          return res
+            .status(registerNewUserToConsumerSideResponse?.status)
+            .json(registerNewUserToConsumerSideResponse?.error);
+        } else {
+          return res
+            .status(registerNewUserToConsumerSideResponse?.status)
+            .json(registerNewUserToConsumerSideResponse?.consent);
+        }
+      } else if (emailReattachedResponse.status !== 200) {
         return res
           .status(emailReattachedResponse?.status)
           .json(emailReattachedResponse?.message);
@@ -852,7 +876,31 @@ export const giveConsentUser = async (
         triggerDataExchange,
       });
 
-      if (emailReattachedResponse.status !== 200) {
+      if (emailReattachedResponse?.case === "no-consumer-identifier") {
+        // Consumer has never registered this user: auto-register them on the
+        // consumer side (consumer DSC -> registrationUri) instead of failing.
+        const registerNewUserToConsumerSideResponse =
+          await registerNewUserToConsumerSide({
+            privacyNotice,
+            req,
+            providerUserIdentifier,
+            dataProvider,
+            dataConsumer,
+            providerUserIdentifierDocument,
+            data,
+            dataProcessingId,
+          });
+
+        if (registerNewUserToConsumerSideResponse.error) {
+          return res
+            .status(registerNewUserToConsumerSideResponse?.status)
+            .json(registerNewUserToConsumerSideResponse?.error);
+        } else {
+          return res
+            .status(registerNewUserToConsumerSideResponse?.status)
+            .json(registerNewUserToConsumerSideResponse?.consent);
+        }
+      } else if (emailReattachedResponse.status !== 200) {
         return res
           .status(emailReattachedResponse?.status)
           .json(emailReattachedResponse?.message);
@@ -1733,7 +1781,7 @@ const registerNewUserToConsumerSide = async ({
   dataProcessingId?: string;
 }): Promise<{ consent?: any; error?: string; status: number }> => {
   //draft consent
-  let consent;
+  let consent: any;
   const verifyDraftConsent = await Consent.findOne({
     privacyNotice: privacyNotice._id,
     providerUserIdentifier: providerUserIdentifier,
@@ -1746,6 +1794,10 @@ const registerNewUserToConsumerSide = async ({
     consented: false,
     contract: privacyNotice.contract,
   });
+
+  // Whether this call created the draft/pending consent. Used to clean it up if
+  // contacting the consumer side fails, so we never leave an orphan behind.
+  const createdHere = !verifyDraftConsent;
 
   if (!verifyDraftConsent) {
     consent = new Consent({
@@ -1769,21 +1821,29 @@ const registerNewUserToConsumerSide = async ({
     consent = verifyDraftConsent;
   }
 
-  // call new dsc endpoint
-  //login
-  const consumerLogin = await axios.post(
-    urlChecker(dataConsumer.dataspaceEndpoint, "login"),
-    {
-      serviceKey: dataConsumer.clientID,
-      secretKey: dataConsumer.clientSecret,
-    },
-    {
-      headers: { "Content-Type": "application/json" },
+  // Delete the draft/pending consent we just created when the consumer side
+  // cannot be reached, so failed attempts don't accumulate orphan consents.
+  const cleanupOrphanConsent = async () => {
+    if (createdHere && consent?._id) {
+      await Consent.deleteOne({ _id: consent._id });
     }
-  );
+  };
 
   //post to register user app side
   try {
+    // call new dsc endpoint
+    //login
+    const consumerLogin = await axios.post(
+      urlChecker(dataConsumer.dataspaceEndpoint, "login"),
+      {
+        serviceKey: dataConsumer.clientID,
+        secretKey: dataConsumer.clientSecret,
+      },
+      {
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+
     const consumerRegisterUserAppSide = await axios.post(
       urlChecker(dataConsumer.dataspaceEndpoint, "private/users/app"),
       {
@@ -1803,7 +1863,15 @@ const registerNewUserToConsumerSide = async ({
         consent,
       };
     }
+
+    // Consumer reached but responded with an unexpected (non-200) status.
+    await cleanupOrphanConsent();
+    return {
+      status: 400,
+      error: "Registration Error.",
+    };
   } catch (e) {
+    await cleanupOrphanConsent();
     if (e?.response?.status === 404) {
       return {
         status: 400,
@@ -1856,9 +1924,13 @@ const emailReattached = async ({
   );
 
   if (!existingConsumerUserIdentifier) {
+    // The consumer has no identifier for this email at all (brand-new user the
+    // consumer doesn't know yet). Flag the case so callers can route it to
+    // consumer-side auto-registration instead of dead-ending here.
     return {
       message: "No user identifier found in the consumer for email " + email,
       status: 404,
+      case: "no-consumer-identifier",
     };
   } else {
     // User identifier found but not attached to the main user, requires user validation
@@ -2137,9 +2209,11 @@ export const redirectPDI = async (
               ),
             },
             {
-              status: {
-                $nin: ["terminated", "revoked"],
-              },
+              // Only an actionable (granted) consent should be surfaced to the
+              // iframe as an editable consentId. draft/pending consents are
+              // internal, user-less placeholders and would wrongly flip the UI
+              // to "Reconfirmer" for a brand-new user.
+              status: "granted",
             },
             {
               child: { $exists: false },

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -149,7 +149,8 @@ export const verifyUserJWT = async (
     });
 
     if (userExisitingIdentifier) {
-      req.userIdentifier = {
+      // A User already links this identifier — authenticate as that User.
+      req.user = {
         id: userExisitingIdentifier._id,
       };
       next();
@@ -159,9 +160,14 @@ export const verifyUserJWT = async (
       });
 
       if (!userExisitingEmail) {
-        return res
-          .status(401)
-          .json({ message: "User with email doesn't exist" });
+        // No User links this identifier yet (e.g. the user is registered on
+        // only one side of the contract). Don't reject — carry the resolved
+        // userIdentifier so the controller can resolve it and drive
+        // consumer-side registration.
+        req.userIdentifier = {
+          id: userIdentifier._id,
+        };
+        return next();
       }
 
       if (

--- a/src/tests/consentRegistration.spec.ts
+++ b/src/tests/consentRegistration.spec.ts
@@ -1,0 +1,312 @@
+/**
+ * Regression tests for the "consent flow dead-ends when only one participant
+ * has registered the user" fix.
+ *
+ * Scenario under test: a user is known to the PROVIDER only. The consumer has
+ * no UserIdentifier for that email and no linked User exists yet.
+ *
+ * These tests lock in:
+ *  - PRIMARY: giveConsent routes the consumer-unknown user into
+ *    registerNewUserToConsumerSide (consumer DSC -> registrationUri) instead of
+ *    dead-ending with 404. (consentsController.ts: emailReattached fall-through)
+ *  - Orphan cleanup: a failed consumer-side registration leaves no orphan
+ *    draft/pending consent behind. (registerNewUserToConsumerSide)
+ *  - Auth pass-through: verifyUserJWT no longer 401s a userIdentifier with no
+ *    linked User. (middleware/auth.ts)
+ *  - Receipt safety: consentToConsentReceipt does not crash on a user-less
+ *    consent. (utils/consentReceipt.ts)
+ *  - redirectPDI only surfaces a *granted* consent as an editable consentId,
+ *    so a brand-new user sees "Accepter" rather than a spurious "Reconfirmer".
+ */
+import { expect } from "chai";
+import supertest from "supertest";
+import { Application } from "express";
+import { startServer } from "../server";
+import { IncomingMessage, ServerResponse } from "http";
+import * as http from "http";
+import nock from "nock";
+import mongoose from "mongoose";
+import { setupnockMocks } from "./fixtures/mock";
+import { testProvider1, testConsumer1 } from "./fixtures/testAccount";
+import Consent from "../models/Consent/Consent.model";
+import Participant from "../models/Participant/Participant.model";
+import User from "../models/User/User.model";
+import { consentToConsentReceipt } from "../utils/consentReceipt";
+
+const CONSUMER_DSC = "https://consumer-dsc.test";
+const CONTRACT_URI = "http://localhost:8888/contracts/65e5d715c99e484e4685a964";
+
+describe("Consent registration fix (single-side registered user)", function () {
+  let serverInstance: {
+    app: Application;
+    server: http.Server<typeof IncomingMessage, typeof ServerResponse>;
+  };
+  let app: Application;
+
+  let providerId: string;
+  let consumerId: string;
+  let providerJWT: string;
+  let providerBase64: string;
+  let consumerBase64: string;
+  let selfDescConsumer: string;
+
+  // Provider-only userIdentifiers (unique emails => no consumer side, no User)
+  let lonerPrimary: string; // PRIMARY happy-path
+  let lonerCleanup: string; // orphan-cleanup
+  let lonerAuth: string; // auth pass-through
+  let lonerPdiPending: string; // redirectPDI pending
+  let grantedIdentifier: string; // redirectPDI granted
+
+  let privacyNoticeId: string;
+  let noticeData: any[];
+
+  const EMAIL_PRIMARY = "loner.primary@example.com";
+  const EMAIL_CLEANUP = "loner.cleanup@example.com";
+  const EMAIL_AUTH = "loner.auth@example.com";
+  const EMAIL_PDI_PENDING = "loner.pdi@example.com";
+  const EMAIL_GRANTED = "loner.granted@example.com";
+
+  // The nock fixtures in ./fixtures/mock.ts intercept the contract service at
+  // http://localhost:8888. Point the app at that host while this suite runs.
+  let originalContractBaseUrl: string | undefined;
+
+  const registerProviderIdentifier = async (email: string) => {
+    const res = await supertest(app)
+      .post(`/v1/users/register`)
+      .set("Authorization", providerJWT)
+      .send({ email, identifier: email });
+    return res.body._id as string;
+  };
+
+  before(async () => {
+    nock.cleanAll();
+
+    originalContractBaseUrl = process.env.CONTRACT_SERVICE_BASE_URL;
+    process.env.CONTRACT_SERVICE_BASE_URL = "http://localhost:8888";
+
+    await mongoose.connect(process.env.MONGO_URI_TEST);
+    await mongoose.connection.dropDatabase();
+
+    serverInstance = await startServer(9091);
+    app = serverInstance.app;
+
+    // Provider
+    const providerResponse = await supertest(app)
+      .post(`/v1/participants/`)
+      .send(testProvider1);
+    providerId = providerResponse.body._id;
+    providerBase64 = Buffer.from(testProvider1.selfDescriptionURL).toString(
+      "base64"
+    );
+
+    const providerAuthResponse = await supertest(app)
+      .post(`/v1/participants/login`)
+      .send({
+        clientID: testProvider1.clientID,
+        clientSecret: testProvider1.clientSecret,
+      });
+    providerJWT = `Bearer ${providerAuthResponse.body.jwt}`;
+
+    // Consumer (deliberately WITHOUT a user identifier for our loner emails)
+    const consumerResponse = await supertest(app)
+      .post(`/v1/participants/`)
+      .send(testConsumer1);
+    consumerId = consumerResponse.body._id;
+    selfDescConsumer = testConsumer1.selfDescriptionURL;
+    consumerBase64 = Buffer.from(testConsumer1.selfDescriptionURL).toString(
+      "base64"
+    );
+
+    // Give the consumer a reachable dataspace endpoint so
+    // registerNewUserToConsumerSide can contact it (we nock it below).
+    await Participant.findByIdAndUpdate(consumerId, {
+      dataspaceEndpoint: CONSUMER_DSC,
+    });
+
+    // Provider-only identifiers (unique emails => checkUserIdentifier creates
+    // no User because there is no matching identifier on another participant).
+    lonerPrimary = await registerProviderIdentifier(EMAIL_PRIMARY);
+    lonerCleanup = await registerProviderIdentifier(EMAIL_CLEANUP);
+    lonerAuth = await registerProviderIdentifier(EMAIL_AUTH);
+    lonerPdiPending = await registerProviderIdentifier(EMAIL_PDI_PENDING);
+    grantedIdentifier = await registerProviderIdentifier(EMAIL_GRANTED);
+
+    // Generate the privacy notice from the contract and capture its id + data.
+    setupnockMocks(providerBase64);
+    const noticeResponse = await supertest(app)
+      .get(`/v1/consents/${lonerPrimary}/${providerBase64}/${consumerBase64}`)
+      .set("x-user-key", lonerPrimary)
+      .expect(200);
+    privacyNoticeId = noticeResponse.body[0]?._id;
+    noticeData =
+      noticeResponse.body?.[0]?.data?.length > 0
+        ? noticeResponse.body[0].data
+        : [{ resource: "test-resource" }];
+  });
+
+  after(async () => {
+    process.env.CONTRACT_SERVICE_BASE_URL = originalContractBaseUrl;
+    serverInstance?.server.close();
+  });
+
+  // PRIMARY fix
+  it("auto-registers the user on the consumer side instead of returning 404", async () => {
+    setupnockMocks(providerBase64);
+    const loginScope = nock(CONSUMER_DSC)
+      .post("/login")
+      .reply(200, { content: { token: "consumer-dsc-token" } });
+    const registrationScope = nock(CONSUMER_DSC)
+      .post("/private/users/app")
+      .reply(200, { ok: true });
+
+    const response = await supertest(app)
+      .post(`/v1/consents`)
+      .set("x-user-key", lonerPrimary)
+      .send({
+        privacyNoticeId,
+        email: EMAIL_PRIMARY,
+        data: noticeData,
+        event: "given",
+      });
+
+    expect(
+      loginScope.isDone(),
+      "consumer DSC /login should be called"
+    ).to.equal(true);
+    expect(
+      registrationScope.isDone(),
+      "consumer DSC /private/users/app (the registrationUri proxy) should be reached"
+    ).to.equal(true);
+    expect(response.status).to.equal(200);
+
+    const pending = await Consent.findOne({
+      providerUserIdentifier: lonerPrimary,
+      privacyNotice: privacyNoticeId,
+    });
+    expect(pending, "a pending consent should be created").to.not.be.null;
+    expect(pending?.status).to.equal("pending");
+  });
+
+  // Orphan cleanup
+  it("leaves no orphan consent when the consumer DSC registration fails", async () => {
+    setupnockMocks(providerBase64);
+    nock(CONSUMER_DSC)
+      .post("/login")
+      .reply(200, { content: { token: "consumer-dsc-token" } });
+    nock(CONSUMER_DSC)
+      .post("/private/users/app")
+      .reply(404, { error: "no registration uri configured" });
+
+    const response = await supertest(app)
+      .post(`/v1/consents`)
+      .set("x-user-key", lonerCleanup)
+      .send({
+        privacyNoticeId,
+        email: EMAIL_CLEANUP,
+        data: noticeData,
+        event: "given",
+      });
+
+    expect(response.status).to.equal(400);
+
+    const orphan = await Consent.findOne({
+      providerUserIdentifier: lonerCleanup,
+      privacyNotice: privacyNoticeId,
+    });
+    expect(
+      orphan,
+      "the draft/pending consent must be cleaned up after a consumer-side failure"
+    ).to.be.null;
+  });
+
+  // Auth pass-through
+  it("does not 401 a userIdentifier that has no linked User", async () => {
+    setupnockMocks(providerBase64);
+    const contractBase64 = Buffer.from(CONTRACT_URI).toString("base64");
+
+    const response = await supertest(app)
+      .get(
+        `/v1/consents/${lonerAuth}/${providerBase64}/${consumerBase64}/${contractBase64}`
+      )
+      .set("x-user-key", lonerAuth);
+
+    expect(
+      response.status,
+      "verifyUserJWT must pass through instead of returning 401"
+    ).to.not.equal(401);
+    expect(response.status).to.equal(200);
+    expect(response.body).to.be.an("array");
+  });
+
+  // Receipt null-safety
+  it("builds a consent receipt without crashing when the consent has no user", async () => {
+    setupnockMocks(providerBase64);
+
+    const receipt = await consentToConsentReceipt({
+      _id: new mongoose.Types.ObjectId(),
+      user: null,
+      dataConsumer: consumerId,
+      dataProvider: providerId,
+      privacyNotice: privacyNoticeId,
+      schema_version: "0.2.0",
+      purposes: [],
+      event: [],
+    } as any);
+
+    expect(receipt.record.piiPrincipalId).to.equal(null);
+  });
+
+  // redirectPDI: pending consent must NOT be surfaced as an editable consentId
+  it("does not surface a pending consent as an editable consentId", async () => {
+    setupnockMocks(providerBase64);
+    await Consent.create({
+      contract: CONTRACT_URI,
+      providerUserIdentifier: lonerPdiPending,
+      consented: false,
+      dataProvider: providerId,
+      dataConsumer: consumerId,
+      recipients: [selfDescConsumer],
+      privacyNotice: privacyNoticeId,
+      status: "pending",
+    });
+
+    const response = await supertest(app)
+      .get(`/v1/consents/pdi/iframe`)
+      .set("Authorization", providerJWT)
+      .query({ userIdentifier: lonerPdiPending, privacyNoticeId })
+      .expect(302);
+
+    expect(
+      response.headers.location,
+      "a pending consent must not flip the iframe into re-confirm mode"
+    ).to.not.include("consentId=");
+  });
+
+  // redirectPDI: granted consent IS surfaced as an editable consentId
+  it("surfaces a granted consent as an editable consentId", async () => {
+    setupnockMocks(providerBase64);
+    const grantedUser = await User.create({
+      email: EMAIL_GRANTED,
+      identifiers: [grantedIdentifier],
+    });
+    await Consent.create({
+      contract: CONTRACT_URI,
+      providerUserIdentifier: grantedIdentifier,
+      consented: true,
+      user: grantedUser._id,
+      dataProvider: providerId,
+      dataConsumer: consumerId,
+      recipients: [selfDescConsumer],
+      privacyNotice: privacyNoticeId,
+      status: "granted",
+    });
+
+    const response = await supertest(app)
+      .get(`/v1/consents/pdi/iframe`)
+      .set("Authorization", providerJWT)
+      .query({ userIdentifier: grantedIdentifier, privacyNoticeId })
+      .expect(302);
+
+    expect(response.headers.location).to.include("consentId=");
+  });
+});

--- a/src/utils/consentReceipt.ts
+++ b/src/utils/consentReceipt.ts
@@ -28,7 +28,7 @@ export const consentToConsentReceipt = async (
     record: {
       schemaVersion: consent.schema_version,
       recordId: consent._id,
-      piiPrincipalId: consent.user.toString(),
+      piiPrincipalId: consent.user?.toString() ?? null,
     },
     piiProcessing: {
       privacyNotice: consent.privacyNotice.toString(),


### PR DESCRIPTION
This pull request addresses a critical issue in the consent registration flow where users registered only on the provider side would encounter dead-ends or errors when attempting to give consent. The changes ensure that such users are automatically registered on the consumer side when necessary, prevent orphaned draft consents, and improve the robustness and correctness of consent handling and authentication. Comprehensive regression tests have been added to lock in these behaviors.

Key changes include:

**Consent Registration Flow Improvements:**
- Updated `giveConsent` and `giveConsentUser` controllers to route users unknown to the consumer into an automatic consumer-side registration flow instead of failing with a 404. This ensures the consent process continues smoothly for provider-only users. [[1]](diffhunk://#diff-c1ea7e5af886d5f86fbab5c9863e7dfac7bad251840f2f38db123bae6d5a71caL508-R532) [[2]](diffhunk://#diff-c1ea7e5af886d5f86fbab5c9863e7dfac7bad251840f2f38db123bae6d5a71caL855-R903)
- Enhanced the `registerNewUserToConsumerSide` helper to clean up any orphaned draft/pending consents if consumer-side registration fails, preventing accumulation of unused records. [[1]](diffhunk://#diff-c1ea7e5af886d5f86fbab5c9863e7dfac7bad251840f2f38db123bae6d5a71caR1798-R1801) [[2]](diffhunk://#diff-c1ea7e5af886d5f86fbab5c9863e7dfac7bad251840f2f38db123bae6d5a71caR1824-R1833) [[3]](diffhunk://#diff-c1ea7e5af886d5f86fbab5c9863e7dfac7bad251840f2f38db123bae6d5a71caR1866-R1874)
- Modified the `emailReattached` helper to signal when a user is unknown to the consumer, enabling the new registration flow.

**Authentication and Consent Handling Fixes:**
- Changed `verifyUserJWT` middleware to allow requests through when a user identifier exists but is not yet linked to a User, supporting the new registration flow instead of returning a 401 error. [[1]](diffhunk://#diff-ffadd6d72f4f9b739e0eae864423032b922aa491a4384fd3f422481794779c21L152-R153) [[2]](diffhunk://#diff-ffadd6d72f4f9b739e0eae864423032b922aa491a4384fd3f422481794779c21L162-R170)
- Updated `consentToConsentReceipt` utility to safely handle consents without a linked user, avoiding crashes in edge cases.
- Ensured `redirectPDI` only surfaces a granted consent as editable in the UI, preventing pending/draft consents from triggering incorrect UI states for new users.

**Testing and Maintenance:**
- Added a comprehensive regression test suite (`src/tests/consentRegistration.spec.ts`) that covers all critical scenarios, including consumer-side registration, orphan cleanup, authentication pass-through, receipt null-safety, and correct UI behavior for pending vs. granted consents.
- Bumped the package version to `1.2.1` to reflect these important fixes.